### PR TITLE
Minor bug and performance fixes

### DIFF
--- a/sudo.lua
+++ b/sudo.lua
@@ -125,8 +125,8 @@ local function env_has(key)
   -- local SP,PM = SUDO__IS_PLATINUM, is_platinum_member(game.player)
   -- if NN and ( (not IP) or (SP or PM) ) then return true end
   --v2: limited evaluation
-  if (env[key] ~= nil) and (
-   (not plat[name])
+  if (this ~= nil) and (
+   (not plat[key])
     or SUDO__IS_PLATINUM 
     or is_platinum_member(game.player)
     ) then return true end

--- a/sudo.lua
+++ b/sudo.lua
@@ -129,7 +129,7 @@ local function env_has(key)
    (not plat[key])
     or SUDO__IS_PLATINUM 
     or is_platinum_member(game.player)
-    ) then return true end
+    ) then return true, this end
   end
 
 --intercept calls to existing __index method (if any)
@@ -142,16 +142,19 @@ local meta = debug.getmetatable(_ENV) or {}; debug.setmetatable(_ENV,meta)
 local idx = meta.__index
 if idx == nil then --host has no __index method
   meta.__index = function(self,key)
-    if env_has(key) then return env[key] end
+    local has, val = env_has(key)
+    if has then return val end
     end
 elseif type(idx) == 'table' then --host has reference table
   meta.__index = function(self,key)
-    if env_has(key) then return env[key] end
+    local has, val = env_has(key)
+    if has then return val end
     return idx[key]
     end
 elseif type(idx) == 'function' then --host has custom function
   meta.__index = function(self,key)
-    if env_has(key) then return env[key] end
+    local has, val = env_has(key)
+    if has then return val end
     return idx(self,key)
     end
 else


### PR DESCRIPTION
- Fixed broken is-platinum check in `env_has()`
	The v2 check for whether a given identifier is a "platinum" feature checked `plat[name]` instead of `plat[key]`. If `name` was defined elsewhere, results would depend on its value; if `name` was not defined, nothing would ever be restricted.
- Removed excess function calls on dynamic values
	Two such cases were found and fixed, reducing generation calls for existing dynamic values from three per access to one:
	- `env_has(key)`
		The metatable applied to `env` looks up dynamic values in the `dyn` table, and if such a value is found, its function is called immediately. The original version of `env_has` accessed `env[key]` to store into a local variable which was originally used in v1 of the check. In v2 however, `env[key]` was directly accessed a second time for the new check, which would have unnecessarily re-executed the function for a dynamic value.
	- The custom `_ENV` metatables
		The metatables applied to `_ENV` to inject lookups call `env_has(key)`, which performs a lookup of `env[key]`, which can invoke a dynamic value's function call. If a value is found and `env_has(key)` returns true, the metatables would then re-access `env[key]`, thereby invoking the dynamic value's generation function a second time. The `env_has(key)` function now returns the value of `env[key]` alongside `true`, which allows lookups to no longer double up on dynamic value generation.

Please note that custom functions injected into the lua environment at the bottom were _not_ modified, but a number of cases were noted where values were repeatedly accessed from `env` within the same function, which will also cause multiple lookups when that function executes. For optimal performance, these values should probably be stored in a function-local variable instead.